### PR TITLE
Offline flag

### DIFF
--- a/install/requirements.txt
+++ b/install/requirements.txt
@@ -370,7 +370,6 @@ six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
     # via python-dateutil
-git+https://github.com/emboman13/python-tuf-lazy-refresh.git
 typing-extensions==4.5.0 \
     --hash=sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb \
     --hash=sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4

--- a/install/requirements.txt
+++ b/install/requirements.txt
@@ -370,11 +370,7 @@ six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
     # via python-dateutil
-# tuf==2.1.0 \
-#     --hash=sha256:ab22d1143d4d8aa20c94d243de27eedc8cd517e251ddaf4a88c10952358a13ea \
-#     --hash=sha256:dbfe18fbdeba6d76144931db88b76e473fa40c431b60d25b455a9adbb07c2397
-    # via sigstore
-git+https://github.com/emboman13/python-tuf-lazy-refresh/tree/offline.git
+git+https://github.com/emboman13/python-tuf-lazy-refresh.git
 typing-extensions==4.5.0 \
     --hash=sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb \
     --hash=sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4

--- a/sigstore/_internal/tuf.py
+++ b/sigstore/_internal/tuf.py
@@ -19,6 +19,7 @@ TUF functionality for `sigstore-python`.
 from __future__ import annotations
 
 import logging
+import sys
 from datetime import datetime, timezone
 from functools import lru_cache
 from pathlib import Path
@@ -117,7 +118,6 @@ class TrustUpdater:
         self._metadata_dir, self._targets_dir = _get_dirs(url)
         # Check for offline flag
         self.offline = "--offline" in sys.argv
-        self.lazy_refresh = "--lazy_refresh" in sys.argv
 
         rsrc_prefix: str
         if self._repo_url == DEFAULT_TUF_URL:

--- a/sigstore/_internal/tuf.py
+++ b/sigstore/_internal/tuf.py
@@ -185,10 +185,10 @@ class TrustUpdater:
         # https://github.com/theupdateframework/python-tuf/issues/2225
         try:
             updater.refresh()
-        except TUFExceptions.ExpiredMetadataError as exp_e:
+        except TUFExceptions.NetworkUnavailableError as network_e:
             raise TUFError(
                 "Local metadata is not available and you are in offline mode"
-            ) from exp_e
+            ) from network_e
         except Exception as e:
             raise TUFError("Failed to refresh TUF metadata") from e
 

--- a/sigstore/_internal/tuf.py
+++ b/sigstore/_internal/tuf.py
@@ -115,7 +115,7 @@ class TrustUpdater:
         """
         self._repo_url = url
         self._metadata_dir, self._targets_dir = _get_dirs(url)
-        # Check for offline and lazy_refresh flags
+        # Check for offline flag
         self.offline = "--offline" in sys.argv
         self.lazy_refresh = "--lazy_refresh" in sys.argv
 
@@ -171,7 +171,7 @@ class TrustUpdater:
     @lru_cache()
     def _updater(self) -> Updater:
         """Initialize and update the toplevel TUF metadata"""
-        configClass = config.UpdaterConfig(offline=self.offline, lazy_refresh=self.lazy_refresh)
+        configClass = config.UpdaterConfig(offline=self.offline)
         updater = Updater(
             metadata_dir=str(self._metadata_dir),
             metadata_base_url=self._repo_url,

--- a/sigstore/_internal/tuf.py
+++ b/sigstore/_internal/tuf.py
@@ -34,7 +34,7 @@ from sigstore_protobuf_specs.dev.sigstore.trustroot.v1 import (
     TrustedRoot,
 )
 from tuf.api import exceptions as TUFExceptions
-from tuf.ngclient import RequestsFetcher, Updater, config
+from tuf.ngclient import RequestsFetcher, Updater, config, config
 
 from sigstore._utils import read_embedded
 from sigstore.errors import MetadataError, RootError, TUFError
@@ -115,7 +115,6 @@ class TrustUpdater:
         """
         self._repo_url = url
         self._metadata_dir, self._targets_dir = _get_dirs(url)
-        # change to get from args
         self.offline = True
 
         rsrc_prefix: str


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Resolves sigstore/https://github.com/sigstore/sigstore-python/issues/483
Preliminary attempt to solve the issue of the offline flag still requiring network access. This fork of sigstore-python in combination with a modified python-tuf repository allows sigstore to operate in offline mode if valid local metadata is available. 

Example of modified tuf: https://github.com/emboman13/python-tuf-lazy-refresh

Reviewers can test this PR by creating a python virtual environment where both of these forks are installed as well as the rest of sigstore dependencies. Create an artifact and sign it with sigstore. Verify the bundle of files with --offline passed in to the cli and WiFi fully turned off. Verification is expected to return success as long as signing material was valid at one point. 

(pip install git+https://github.com/emboman13/python-tuf-lazy-refresh/#egg=tuf)

Currently looking into signing and verifying an artifact using a faketime library. Needs unit tests and possibly a better way to grab the offline flag from arguments. 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
--offline allows sigstore to operate with network access fully turned off.
TrustUpdater within tuf.py has an updated config with the offline flag if found from system arguments.
Catches a new exception from tuf (NetworkUnavailableError). 

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
TUF updater skips the checking the expiry of data in the case that local metadata is loaded.